### PR TITLE
「一覧画面へ」のリンク修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <a href="https://mbaas.nifcloud.com/?utm_source=referral&utm_medium=community&utm_campaign=community"><img src="img/mbaas_nifcloud_logo_RGB03.png" alt="" width="700" height="110" border="0" /></a>
 
-<a href="../../issues?q=">
+<a href="../../issues">
   <img src="img/ichirantokou.JPG" alt="一覧" height="60" border="0" />
 </a>
 <a href="../../issues/new">


### PR DESCRIPTION
一覧画面へをクリックすると、m-r履歴も表示されてしまうため、表示されないようにリンクを変更しました。